### PR TITLE
rename fixed deployment

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,7 @@
 on: 
   push: 
     branches: 
-      - main
+      - master
 name: 🚀 When main branch is updated, deploy TC-app to production (skcvolleybal.nl/tc-app)
 jobs:
   web-deploy:


### PR DESCRIPTION
apparently tc-app uses master instead of main as main branch name