### PR TITLE
Set isVisible to fals in Training groups

### DIFF
--- a/services/playerService.js
+++ b/services/playerService.js
@@ -125,7 +125,7 @@
                      id: team.id,
                      name: team.name,
                      sequence: team.sequence,
-                     isVisible: true,
+                     isVisible: false,
                      players: GetPlayersInTeam(team.players)
                   });
                });


### PR DESCRIPTION
This sets the training groups to default not Visible so you have to click the teams that you want to have shown